### PR TITLE
MapStore integration for GN 2.10.x

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115/present/metadata.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115/present/metadata.xsl
@@ -985,6 +985,7 @@
 		<xsl:variable name="name" select="normalize-space(orName)" />
 		<xsl:variable name="description" select="normalize-space(orDesc)" />
 		<xsl:variable name="metadata_id" select="//geonet:info/id" />
+		<xsl:variable name="uuid" select="geonet:info/uuid"/>
 
 		<xsl:choose>
 			<xsl:when test="$edit=true()">
@@ -1002,7 +1003,7 @@
 						<!-- ETJ 
 						<a href="javascript:popInterMap('{/root/gui/url}/intermap/srv/{/root/gui/language}/map.addServicesExt?url={linkage}&amp;service={orName}&amp;type=2')" title="{/root/strings/interactiveMap}">
 						-->
-						<a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}']])" title="{/root/strings/interactiveMap}">
+						<a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}','{$uuid}']])" title="{/root/strings/interactiveMap}">
 								<xsl:choose>
 								<xsl:when test="string($description)!=''">
 									<xsl:value-of select="$description"/>
@@ -1019,7 +1020,7 @@
 					<xsl:with-param name="schema"  select="$schema"/>
 					<xsl:with-param name="title"  select="/root/gui/strings/viewInGE"/>
 					<xsl:with-param name="text">
-						<a href="{/root/gui/locService}/google.kml?uuid={../../../geonet:info/uuid}&amp;layers={$name}" title="{/root/strings/interactiveMap}">
+						<a href="{/root/gui/locService}/google.kml?uuid={$uuid}&amp;layers={$name}" title="{/root/strings/interactiveMap}">
 							<xsl:choose>
 								<xsl:when test="string($description)!=''">
 									<xsl:value-of select="$description"/>
@@ -1143,6 +1144,7 @@
 		<xsl:variable name="linkage" select="linkage" />
 		<xsl:variable name="name" select="normalize-space(orName)" />
 		<xsl:variable name="description" select="normalize-space(orDesc)" />
+		<xsl:variable name="uuid" select="../../../geonet:info/uuid" />
 		
 		<xsl:choose>
 			<xsl:when test="$edit=true()">
@@ -1158,7 +1160,7 @@
 						<!-- ETj
 						<a href="javascript:popInterMap('{/root/gui/url}/intermap/srv/{/root/gui/language}/map.addServicesExt?url={linkage}&amp;service={orName}&amp;type=1')" title="{/root/strings/interactiveMap}">
 						-->
-							<a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}']])" title="{/root/strings/interactiveMap}">
+							<a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}','{$uuid}']])" title="{/root/strings/interactiveMap}">
 								
 							<xsl:choose>
 								<xsl:when test="string($description)!=''">
@@ -1827,7 +1829,7 @@
                     <!-- no protocol, but URL is for a WMS service -->
                      <xsl:when test="(not(string(./protocol)) and contains(upper-case($linkage),'SERVICE=WMS') and string($name)!='')">
 						<link type="wms">
-							<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>
+							<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,&#34;',$uuid,'&#34;]])')"/>
 						</link>
 					</xsl:when>
 					<xsl:when test="starts-with(./protocol,'WWW:DOWNLOAD-') and contains(./protocol,'http--download') and string($linkage)!='' and not(contains($linkage,$download_check))"> <!-- FIXME -->
@@ -1836,13 +1838,13 @@
 					<xsl:when test="starts-with(./protocol,'ESRI:AIMS-') and contains(./protocol,'-get-image') and string($linkage)!='' and string($name)!=''">
 						<link type="arcims">
 							<!-- ETj  <xsl:value-of select="concat('javascript:popInterMap(&#34;',/root/gui/url,'/intermap/srv/',/root/gui/language,'/map.addServicesExt?url=',linkage,'&amp;service=',orName,'&amp;type=1&#34;)')"/> -->							
-							<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>
+							<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,&#34;',$uuid,'&#34;]])')"/>
 						</link>
 					</xsl:when>
 					<xsl:when test="(starts-with(./protocol,'OGC:WMS-') and contains(./protocol,'-get-map') and string($linkage)!='' and string($name)!='')  or ($protocol = 'OGC:WMS' and string($linkage)!='' and string($name)!='')">
 						<link type="wms">
 							<!-- ETj -->
-							<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>
+							<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,&#34;',$uuid,'&#34;]])')"/>
 						</link>
 						<link type="googleearth">
 							<xsl:value-of select="concat(/root/gui/locService,'/google.kml?uuid=',$uuid,'&amp;layers=',$name)"/>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/metadata-edit.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/metadata-edit.xsl
@@ -2641,6 +2641,7 @@
     <xsl:variable name="linkage" select="gmd:linkage/gmd:URL" />
     <xsl:variable name="name" select="normalize-space(gmd:name/gco:CharacterString|gmd:name/gmx:MimeFileType)" />
     <xsl:variable name="description" select="normalize-space(gmd:description/gco:CharacterString)" />
+    <xsl:variable name="uuid" select="{//geonet:info/uuid}" />
     
     <xsl:choose>
       <xsl:when test="$edit=true()">
@@ -2654,7 +2655,7 @@
           <xsl:with-param name="schema"  select="$schema"/>
           <xsl:with-param name="title"  select="/root/gui/strings/interactiveMap"/>
           <xsl:with-param name="text">
-            <a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}']])" title="{/root/strings/interactiveMap}">
+            <a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}','{$uuid}']])" title="{/root/strings/interactiveMap}">
                 <xsl:choose>
                 <xsl:when test="string($description)!=''">
                   <xsl:value-of select="$description"/>
@@ -2671,7 +2672,7 @@
           <xsl:with-param name="schema"  select="$schema"/>
           <xsl:with-param name="title"  select="/root/gui/strings/viewInGE"/>
           <xsl:with-param name="text">
-            <a href="{/root/gui/locService}/google.kml?uuid={//geonet:info/uuid}&amp;layers={$name}" title="{/root/strings/interactiveMap}">
+            <a href="{/root/gui/locService}/google.kml?uuid={$uuid}&amp;layers={$name}" title="{/root/strings/interactiveMap}">
               <xsl:choose>
                 <xsl:when test="string($description)!=''">
                   <xsl:value-of select="$description"/>
@@ -3095,7 +3096,7 @@
           </xsl:when>
           <xsl:when test="starts-with($protocol,'OGC:WMS-') and contains($protocol,'-get-map') and string($linkage)!='' and string($name)!=''">
             <link type="wms">
-              <xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>
+              <xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,'&#34;,&#34;',$uuid,'&#34;]])')"/>
             </link>
             <link type="googleearth">
               <xsl:value-of select="concat(/root/gui/locService,'/google.kml?uuid=',$uuid,'&amp;layers=',$name)"/>
@@ -3104,7 +3105,7 @@
           <xsl:when test="starts-with($protocol,'OGC:WMS-') and contains($protocol,'-get-capabilities') and string($linkage)!=''">
             <link type="wms">
               <!--xsl:value-of select="concat('javascript:runIM_selectService(&#34;'  ,  $linkage  ,  '&#34;, 2,',$id,')' )"/-->
-              <xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>            
+              <xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,'&#34;,&#34;',$uuid,'&#34;]])')"/>            
             </link>
           </xsl:when>
           <xsl:when test="string($linkage)!=''">

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/metadata.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/present/metadata.xsl
@@ -2742,6 +2742,7 @@
 		<xsl:variable name="linkage" select="gmd:linkage/gmd:URL" />
 		<xsl:variable name="name" select="normalize-space(gmd:name/gco:CharacterString|gmd:name/gmx:MimeFileType)" />
 		<xsl:variable name="description" select="normalize-space(gmd:description/gco:CharacterString)" />
+		<xsl:variable name="uuid" select="/root/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/geonet:info/uuid" />
 
 		<xsl:choose>
 			<xsl:when test="$edit=true()">
@@ -2756,7 +2757,7 @@
 					<xsl:with-param name="schema"  select="$schema"/>
 					<xsl:with-param name="title"  select="/root/gui/strings/interactiveMap"/>
 					<xsl:with-param name="text">
-						<a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}']])" title="{/root/strings/interactiveMap}">
+						<a href="javascript:addWMSLayer([['{$name}','{$linkage}','{$name}','{$metadata_id}','{$uuid}']])" title="{/root/strings/interactiveMap}">
 							<xsl:choose>
 								<xsl:when test="string($description)!=''">
 									<xsl:value-of select="$description"/>
@@ -2774,7 +2775,7 @@
 					<xsl:with-param name="schema"  select="$schema"/>
 					<xsl:with-param name="title"  select="/root/gui/strings/viewInGE"/>
 					<xsl:with-param name="text">
-						<a href="{/root/gui/locService}/google.kml?uuid={/root/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/geonet:info/uuid}&amp;layers={$name}" title="{/root/strings/interactiveMap}">
+						<a href="{/root/gui/locService}/google.kml?uuid={$uuid}&amp;layers={$name}" title="{/root/strings/interactiveMap}">
 							<xsl:choose>
 								<xsl:when test="string($description)!=''">
 									<xsl:value-of select="$description"/>
@@ -3266,7 +3267,7 @@
 				<!-- no protocol, but URL is for a WMS service -->
 				<xsl:when test="(not(string($protocol)) and contains(upper-case($linkage),'SERVICE=WMS') and string($name)!='')">
 					<link type="wms">
-						<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>
+						<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,&#34;',$uuid,'&#34;]])')"/>
 					</link>
 				</xsl:when>
 				<xsl:when test="matches($protocol,'^WWW:DOWNLOAD-.*-http--download.*') and not(contains($linkage,$download_check))">
@@ -3279,7 +3280,7 @@
 				</xsl:when>
 				<xsl:when test="(starts-with($protocol,'OGC:WMS-') and contains($protocol,'-get-map') and string($linkage)!='' and string($name)!='') or ($protocol = 'OGC:WMS' and string($linkage)!='' and string($name)!='')">
 					<link type="wms">
-						<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;]])')"/>
+						<xsl:value-of select="concat('javascript:addWMSLayer([[&#34;' , $name , '&#34;,&#34;' ,  $linkage  ,  '&#34;, &#34;', $name  ,'&#34;,&#34;',$id,'&#34;,&#34;',$uuid,'&#34;]])')"/>
 					</link>
 					<link type="googleearth">
 						<xsl:value-of select="concat(/root/gui/locService,'/google.kml?uuid=',$uuid,'&amp;layers=',$name)"/>

--- a/web/src/main/webapp/scripts/gn_search.js
+++ b/web/src/main/webapp/scripts/gn_search.js
@@ -1177,14 +1177,22 @@ function toggleWhen() {
 }
 
 function addWMSLayer(layers) {
+	var title = layers[0][0];
+	var wmsURL = layers[0][1];
+	var name = layers[0][2];
+	var id = layers[0][3];
+	var uuid = layers[0][4];
+	parent.addMSLayer(title, name, wmsURL, Env.host + Env.url + "/", true, uuid, Env.lang);
+	/*
 	Ext.getCmp("north-map-panel").expand();
-    GeoNetwork.mapViewer.addWMSLayer(layers);
+    GeoNetwork.mapViewer.addWMSLayer(layers);*/
 }
 
 function addWMSServerLayers(url) {
-	Ext.getCmp("north-map-panel").expand();
+	parent.addMSSource(url);
+	/*Ext.getCmp("north-map-panel").expand();
 	mainViewport.doLayout();
-    GeoNetwork.mapViewer.addWMSServerLayers(url);
+    GeoNetwork.mapViewer.addWMSServerLayers(url);*/
 }
 
 function addSelectedWMSLayers(metadataIdForm) {

--- a/web/src/main/webapp/xsl/banner.xsl
+++ b/web/src/main/webapp/xsl/banner.xsl
@@ -24,7 +24,7 @@
 
         <table width="100%">
 
-            <!-- title -->
+            <!-- title: Hide banner on MapStore integration
             <tr class="banner">
                 <td class="banner">
                     <img src="{/root/gui/url}/images/header-left.jpg" alt="World picture" align="top" />
@@ -32,7 +32,7 @@
                 <td align="right" class="banner">
                     <img src="{/root/gui/url}/images/header-right.gif" alt="GeoNetwork opensource logo" align="top" />
                 </td>
-            </tr>
+            </tr> -->
 
             <!-- buttons -->
             <tr class="banner">

--- a/web/src/main/webapp/xsl/main-page.xsl
+++ b/web/src/main/webapp/xsl/main-page.xsl
@@ -249,6 +249,7 @@
 								border:false,
 								layout: 'border',
 								items: [
+									/* Hide Map viewer on MapStore integration
 									{region:'north',
 									id: 'north-map-panel',
 									title: '<xsl:value-of select="/root/gui/strings/mapViewer"/>',
@@ -266,7 +267,7 @@
 											},
 									items: [mapViewport]
 									
-									},
+									},*/
 									{region:'center', 
 									contentEl :'content',
 									border:false,

--- a/web/src/main/webapp/xsl/metadata-show.xsl
+++ b/web/src/main/webapp/xsl/metadata-show.xsl
@@ -179,6 +179,7 @@
 								border:false,
 								layout: 'border',
 								items: [
+									/* Hide Map viewer on MapStore integration
 									{region:'north',
 									id: 'north-map-panel',
 									title: '<xsl:value-of select="/root/gui/strings/mapViewer"/>',
@@ -196,7 +197,7 @@
 											},
 									items: [mapViewport]
 									
-									},
+									},*/
 									{region:'center', 
 									contentEl :'content',
 									border:false,


### PR DESCRIPTION
- Hide GeoNetwork header
- Remove viewer in GeoNetwork pages
- Changes on `addWMSLayer` and `addWMSServerLayers` functions to integrate with MapStore
- Changes on default schemas iso19115 and iso19139
