### PR TITLE
Massive validation failures

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/XmlResolver.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlResolver.java
@@ -32,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 import org.apache.jcs.access.exception.CacheException;
@@ -195,6 +196,11 @@ public class XmlResolver extends XMLCatalogResolver {
                         Log.error(Log.JEEVES, "Error opening resource: " + resolved + " for reading", e);
                     }
                 }
+            }catch (InvalidPathException ipe){
+                // Instead of throwing an exception logging a warn message.
+                // the calling method will try to resolve it as an external resourcu
+                Log.warning(Log.JEEVES, "Unable to resolve systemId " + systemId +
+                    " locally. Trying to fetch it as an external resource");
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }

--- a/common/src/test/java/org/fao/geonet/utils/XmlResolverTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/XmlResolverTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.utils;
+
+import org.apache.jcs.JCS;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.fao.geonet.JeevesJCS;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.ls.LSInput;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+public class XmlResolverTest {
+
+    XmlResolver xmlResolver;
+
+    @Before
+    public void setUp () throws URISyntaxException {
+        String path = Paths.get(XmlTest.class.getResource("oasis-catalog-test.xml").toURI()).toString();
+        xmlResolver = new XmlResolver(new String []{path}, new ProxyInfo().getProxyParams());
+        JeevesJCS.setConfigFilename(Paths.get(getClass().getResource("xmltest/mock-cache.ccf").toURI()));
+    }
+
+    @Test
+    public void tryResolveOnFsTestWithExternalResource() throws URISyntaxException {
+        // testing that when an external resource is at stake,
+        // the tryResolveOnFs method doesn't throws and exception trying
+        // to resolve the url on local path, but skip it logging a warn message.
+        String path = XmlTest.class.getResource("xmltest/xml.xsd").toURI().toString();
+        String type = "http://www.w3.org/2001/XMLSchema";
+        String namespace = "http://purl.org/dc/elements/1.1/";
+        String onlineXsd = "http://www.w3.org/2001/03/xml.xsd";
+        LSInput result = xmlResolver.resolveResource(type, namespace, null, onlineXsd, path);
+        assertNotNull(result);
+        String data = result.getStringData();
+        assertNotNull(data);
+        assertFalse(data.equals(""));
+
+    }
+
+    @After
+    public void clean (){
+        JeevesJCS.setConfigFilename(null);
+    }
+
+}

--- a/common/src/test/resources/org/fao/geonet/utils/oasis-catalog-test.xml
+++ b/common/src/test/resources/org/fao/geonet/utils/oasis-catalog-test.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
+
+  <!-- OASIS CATALOG FOR GEONETWORK TO REMAP VARIOUS XML IDs -->
+
+  <!-- This used to be done in Java code, but with the use of these
+             maps you can customise this to suit yourself. -->
+
+  <!-- Each schema has an oasis-catalog file for remapping individual
+         xsd schemaLocation hints -->
+
+  <!-- remap system id schema-ident.xsd to local copy in GeoNetwork
+         relative to this catalog file -->
+
+  <system systemId="http://geonetwork-opensource.org/schemas/schema-ident/schema-ident.xsd"
+          uri="../xml/validation/schemaPlugins/schema-ident.xsd"/>
+
+  <system systemId="http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"
+          uri="../xml/validation/oai/OAI-PMH.xsd"/>
+
+  <system systemId="http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+          uri="../xml/validation/oai/dc/oai_dc.xsd"/>
+
+  <system systemId="xml.xsd"
+          uri="../xml/validation/oai/dc/xml.xsd"/>
+
+  <system systemId="XMLSchema.dtd"
+          uri="../xml/validation/oai/dc/XMLSchema.dtd"/>
+
+  <!-- remap utils-fn.xsl included in schematrons to the correct place
+         relative to this catalog file -->
+
+
+  <uri name="../../../xsl/utils-fn.xsl"
+       uri="../xsl/utils-fn.xsl"/>
+
+  <uri name="common/index-utils.xsl"
+       uri="../xslt/common/index-utils.xsl"/>
+
+  <uri name="common/inspire-constant.xsl"
+       uri="../xslt/common/inspire-constant.xsl"/>
+
+  <uri name="common/utility-tpl.xsl"
+       uri="../xslt/common/utility-tpl.xsl"/>
+
+  <uri name="common/render-html.xsl"
+       uri="../xslt/common/render-html.xsl"/>
+
+  <uri name="common/functions-core.xsl"
+       uri="../xslt/common/functions-core.xsl"/>
+
+  <uri name="common/functions-metadata.xsl"
+       uri="../xslt/common/functions-metadata.xsl"/>
+</catalog>

--- a/common/src/test/resources/org/fao/geonet/utils/xmltest/mock-cache.ccf
+++ b/common/src/test/resources/org/fao/geonet/utils/xmltest/mock-cache.ccf
@@ -1,0 +1,11 @@
+jcs.default=DC
+jcs.default.cacheattributes=org.apache.jcs.engine.CompositeCacheAttributes
+jcs.default.cacheattributes.MaxObjects=1000
+jcs.default.cacheattributes.MemoryCacheName=org.apache.jcs.engine.memory.lru.LRUMemoryCache
+
+jcs.default.cacheattributes.UseMemoryShrinker=true
+jcs.default.cacheattributes.MaxMemoryIdleTimeSeconds=3600
+jcs.default.cacheattributes.ShrinkerIntervalSeconds=60
+jcs.default.cacheattributes.MaxSpoolPerRun=500
+jcs.default.elementattributes=org.apache.jcs.engine.ElementAttributes
+jcs.default.elementattributes.IsEternal=false


### PR DESCRIPTION
Fix a bug causing massive validation failures on metadata. The XmlResolver tries to resolve locally an external resource url and exception is not managed to allows to later fetch it from url.This was in turn causing massive validation to fails.