### PR TITLE
add bean overriding on metadata related class in application-context

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -193,10 +193,10 @@
 
 
     <!-- Comment the following beans to get non-draft metadata and uncomment the beans below -->
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataIndexer"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataManager"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataUtils"/>
-    <!--<bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
-    <bean primary="true" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>-->
+    <bean id="metadataIndexer" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataIndexer"/>
+    <bean id="metadataManager" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataManager"/>
+    <bean id="metadataUtils" class="org.fao.geonet.kernel.datamanager.draft.DraftMetadataUtils"/>
+    <!--<bean id="metadataIndexer" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer"/>
+    <bean id="metadataManager" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataManager"/>
+    <bean id="metadataUtils" class="org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils"/>-->
 </beans>


### PR DESCRIPTION
add the possibility to ovverride metada related bean in the application-context, by providing an id to them and removing the primary=true, so that it can be setted in submodule beans.