### PR TITLE
#36 Livello gerarchico - errore rendering

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -616,7 +616,7 @@
                         </textarea>
                       </xsl:when>
                       <xsl:when test="$codelist != ''">
-                        <select class="form-control input-sm"
+                        <select class="form-control"
                                 data-gn-field-tooltip="{$schema}|{@tooltip}"
                                 id="{$id}_{@label}">
                           <xsl:if test="$readonly = 'true'">


### PR DESCRIPTION
- fix issue codeliste se chiamate da template snippet
- issue https://github.com/geosolutions-it/iso19139.rndt/issues/36

When a codelists is invoked from a template snippet eg.:
```
<template>
  <values>
    <key label="hierarchyLevel xpath="gmd:hierarchyLevel/@codeListValue>
       <codelist name="gmd:MD_ScopeCode"/>
    <key>
  </values>
  .....
</template>
```
the template in the form-builder force a small input type producing a bad rendering with the input value not fully visible
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563653431306236643233396631313934353737613962312f36323530393765372d626631342d343164632d383038612d613631396463633235343731](https://user-images.githubusercontent.com/46672505/97164655-c13b2c00-1782-11eb-9afd-1dc735d5e1bd.png)
