### PR TITLE
Fix logo aggiornamento gruppi

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -611,11 +611,11 @@
               <i class="fa fa-fw fa-cog"></i>
               <span data-translate="">sourceCatalog</span>
             </h2>
-            <img data-ng-if="!md.groupWebsite && md.logo"
+            <img data-ng-if="md.logo"
                  data-ng-src="{{gnUrl}}..{{md.logo}}"
                  alt="{{'siteLogo' | translate}}"
                  class="gn-source-logo"/>
-            <img data-ng-if="md.groupWebsite==true"
+            <img data-ng-if="!md.logo"
                  ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.source}}.png"
                  aria-label="{{'sourceCatalog' | translate}}"
                  class="gn-source-logo"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -611,9 +611,14 @@
               <i class="fa fa-fw fa-cog"></i>
               <span data-translate="">sourceCatalog</span>
             </h2>
-            <img ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.source}}.png"
-                aria-label="{{'sourceCatalog' | translate}}"
-                class="gn-source-logo"/>
+            <img data-ng-if="!md.groupWebsite && md.logo"
+                 data-ng-src="{{gnUrl}}..{{md.logo}}"
+                 alt="{{'siteLogo' | translate}}"
+                 class="gn-source-logo"/>
+            <img data-ng-if="md.groupWebsite==true"
+                 ng-src="{{gnUrl}}../images/logos/{{mdView.current.record.source}}.png"
+                 aria-label="{{'sourceCatalog' | translate}}"
+                 class="gn-source-logo"/>
           </section>
 
           <section class="gn-md-side-calendar">


### PR DESCRIPTION
Fix logo del catalogo quando il logo del gruppo viene aggiornato.
Allinea il path da cui recuperare il log con l'html usato per la schermata di ricerca https://github.com/geonetwork/core-geonetwork/blob/8886a147147ff8abf134cc144021bc51383e6370/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html#L23