### PR TITLE
#58 CSW harvester: opt to swap detectSchema and XSL processing

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -291,6 +291,10 @@ public class Aligner extends BaseAligner<CswParams> {
             return;
         }
 
+        if (params.applyXslBeforeSchemaDetection && !params.xslfilter.equals("")) {
+            md = processMetadata(context, md, processName, processParams);
+        }
+
         String schema = dataMan.autodetectSchema(md, null);
         if (schema == null) {
             log.debug("  - Metadata skipped due to unknown schema. uuid:" + ri.uuid);
@@ -310,8 +314,11 @@ public class Aligner extends BaseAligner<CswParams> {
         log.debug("  - Adding metadata with remote uuid:" + ri.uuid + " schema:" + schema);
 
         String mdUuid = ri.uuid;
-        if (!params.xslfilter.equals("")) {
+        if (!params.applyXslBeforeSchemaDetection && !params.xslfilter.equals("")) {
             md = processMetadata(context, md, processName, processParams);
+        }
+
+        if (!params.xslfilter.equals("")){
             // Get new uuid if modified by XSLT process
             mdUuid = metadataUtils.extractUUID(schema, md);
             if (mdUuid == null) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
@@ -57,6 +57,7 @@ public class CswHarvester extends AbstractHarvester<HarvestResult, CswParams> {
         harvesterSettingsManager.add("id:" + siteId, "hopCount", params.hopCount);
         harvesterSettingsManager.add("id:" + siteId, "xpathFilter", params.xpathFilter);
         harvesterSettingsManager.add("id:" + siteId, "xslfilter", params.xslfilter);
+        harvesterSettingsManager.add("id:" + siteId, "applyXslBeforeSchemaDetection", params.applyXslBeforeSchemaDetection);
         harvesterSettingsManager.add("id:" + siteId, "outputSchema", params.outputSchema);
 
         //--- store dynamic search nodes

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
@@ -90,7 +90,7 @@ public class CswParams extends AbstractParams {
         xpathFilter = Util.getParam(site, "xpathFilter", "");
         outputSchema = Util.getParam(site, "outputSchema", outputSchema);
         icon = Util.getParam(site, "icon", "default.gif");
-        applyXslBeforeSchemaDetection =Util.getParam(site,"applyXslBeforeSchemaDetection", false);
+        applyXslBeforeSchemaDetection = Util.getParam(site, "applyXslBeforeSchemaDetection", false);
         if (searches != null) {
             if (searches.getChild("search") != null) {
                 @SuppressWarnings("unchecked")
@@ -119,7 +119,7 @@ public class CswParams extends AbstractParams {
         hopCount = Util.getParam(site, "hopCount", hopCount);
         xpathFilter = Util.getParam(site, "xpathFilter", "");
         xslfilter = Util.getParam(site, "xslfilter", "");
-        applyXslBeforeSchemaDetection =Util.getParam(site,"applyXslBeforeSchemaDetection", false);
+        applyXslBeforeSchemaDetection =Util.getParam(site, "applyXslBeforeSchemaDetection", false);
         outputSchema = Util.getParam(site, "outputSchema", outputSchema);
 
         icon = Util.getParam(site, "icon", icon);
@@ -155,7 +155,7 @@ public class CswParams extends AbstractParams {
         copy.outputSchema = outputSchema;
 
         copy.eltSearches = eltSearches;
-        copy.applyXslBeforeSchemaDetection=applyXslBeforeSchemaDetection;
+        copy.applyXslBeforeSchemaDetection = applyXslBeforeSchemaDetection;
         return copy;
     }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswParams.java
@@ -61,6 +61,8 @@ public class CswParams extends AbstractParams {
     public String xslfilter;
     public List<Element> eltSearches = new ArrayList<Element>();
 
+    public boolean applyXslBeforeSchemaDetection;
+
     @Override
     public String getIcon() {
         return icon;
@@ -88,7 +90,7 @@ public class CswParams extends AbstractParams {
         xpathFilter = Util.getParam(site, "xpathFilter", "");
         outputSchema = Util.getParam(site, "outputSchema", outputSchema);
         icon = Util.getParam(site, "icon", "default.gif");
-
+        applyXslBeforeSchemaDetection =Util.getParam(site,"applyXslBeforeSchemaDetection", false);
         if (searches != null) {
             if (searches.getChild("search") != null) {
                 @SuppressWarnings("unchecked")
@@ -117,6 +119,7 @@ public class CswParams extends AbstractParams {
         hopCount = Util.getParam(site, "hopCount", hopCount);
         xpathFilter = Util.getParam(site, "xpathFilter", "");
         xslfilter = Util.getParam(site, "xslfilter", "");
+        applyXslBeforeSchemaDetection =Util.getParam(site,"applyXslBeforeSchemaDetection", false);
         outputSchema = Util.getParam(site, "outputSchema", outputSchema);
 
         icon = Util.getParam(site, "icon", icon);
@@ -152,7 +155,7 @@ public class CswParams extends AbstractParams {
         copy.outputSchema = outputSchema;
 
         copy.eltSearches = eltSearches;
-
+        copy.applyXslBeforeSchemaDetection=applyXslBeforeSchemaDetection;
         return copy;
     }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -21,6 +21,7 @@
     "andNodeLogo": " and logo",
     "applyXSLToRecord": "XSL transformation to apply",
     "applyXSLToRecordHelp": "The referenced XSL transform will be applied to each metadata record before it is added to Geonetwork",
+    "applyXSLTBeforeSchemaDetection": "Apply XSL Transformation before schema detection",
     "arcsde-database": "Database",
     "arcsde-databaseHelp": "The ArcSDE database name",
     "arcsde-port": "Port",

--- a/web-ui/src/main/resources/catalog/locales/it-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/it-admin.json
@@ -21,6 +21,7 @@
     "andNodeLogo": "e logo",
     "applyXSLToRecord": "Trasformazione XSL da applicare",
     "applyXSLToRecordHelp": "La trasformazione XSL verrà applicata ad ogni record di metadati prima che lo stesso venga aggiunto a Geonetwork",
+    "applyXSLTBeforeSchemaDetection": "Esegui la trasformazione XSL prima del detect dello schema",
     "arcsde-database": "Banca dati",
     "arcsde-databaseHelp": "Il nome del database ArcSDE",
     "arcsde-port": "Porta",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -133,6 +133,11 @@
       <div id="gn-harvest-settings-csw-advanced-xsl-list" data-gn-import-xsl="harvesterSelected.site.xslfilter"/>
 
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
+      <input id="gn-harvest-settings-apply-before-schema-checkbox"
+               type="checkbox"
+               data-ng-model="harvesterSelected.site.applyXslBeforeSchemaDetection"/>
+      <label id="gn-harvest-settings-csw-apply-before-schema-label" class="control-label" data-translate="">applyXSLTBeforeSchemaDetection</label>
+      </label>
     </div>
     <div id="gn-harvest-settings-csw-advanced-scheme-row">
       <div class="row">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.js
@@ -21,6 +21,7 @@ var gnHarvestercsw = {
         "xpathFilter" : "",
         "rejectDuplicateResource" : false,
         "xslfilter": [],
+        "applyXslBeforeSchemaDetection" : false,
         "outputSchema": "http://www.isotc211.org/2005/gmd",
         "queryScope": "local",
         "hopCount": 2
@@ -89,6 +90,7 @@ var gnHarvestercsw = {
       + '    </account>'
       + '    <xpathFilter>' + h.site.xpathFilter + '</xpathFilter>'
       + '    <xslfilter>' + h.site.xslfilter + '</xslfilter>'
+      + '    <applyXslBeforeSchemaDetection>' + h.site.applyXslBeforeSchemaDetection + '</applyXslBeforeSchemaDetection>'
       + '    <outputSchema>' + h.site.outputSchema + '</outputSchema>'
       + '    <queryScope>' + h.site.queryScope + '</queryScope>'
       + '    <hopCount>' + h.site.hopCount + '</hopCount>'

--- a/web/src/main/webapp/xsl/xml/harvesting/csw.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/csw.xsl
@@ -22,6 +22,9 @@
     <xslfilter>
       <xsl:value-of select="xslfilter/value"/>
     </xslfilter>
+    <applyXslBeforeSchemaDetection>
+      <xsl:value-of select="applyXslBeforeSchemaDetection/value"/>
+    </applyXslBeforeSchemaDetection>
     <queryScope>
       <xsl:value-of select="queryScope/value"/>
     </queryScope>


### PR DESCRIPTION
- Aggiunge da UI una checkbox per permettere il processing dei metadati harvestati prima della schema detection
- Gestisce la nuova opzione a livello di harvesting per effettuare la trasformazione xsl prima o dopo la schema detection in accordo con il valore della checkbox